### PR TITLE
Update index.ts - 移除`at查询余额`无参数的help提示，直接查询自己，无需返回帮助

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -225,9 +225,6 @@ export async function apply(ctx: Context, config: Config) {
       let targetUserId: string = session.userId; // 默认查询自己
       let targetUsername: string = session.username;
       let parsedUser: any;
-      if (!userArg) {
-        await session.execute(`monetaryRank.查询货币 -h`);
-      }
 
       if (userArg) {
         parsedUser = h.parse(userArg)[0];


### PR DESCRIPTION

at查询应该允许不带at参数，而不是再返回一次help帮助

移除`at查询余额`无参数的help提示，直接查询自己，无需返回帮助

---

->  https://github.com/shangxueink/koishi-shangxue-apps/issues/91#issuecomment-2664867554